### PR TITLE
feat: strip llvm-prebuilt intermediate files

### DIFF
--- a/Dockerfile.llvm
+++ b/Dockerfile.llvm
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+# Builder.
+FROM ubuntu:20.04 as builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -33,9 +34,22 @@ RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER
 
 ARG MAKE_THREADS=32
 
-# Build llvm12 from source code.
-RUN git clone --branch release/12.x --single-branch https://github.com/llvm/llvm-project.git \
-    && mkdir -p llvm-project/build \
-    && cd llvm-project/build \
-    && cmake -DLLVM_ENABLE_PROJECTS="clang;openmp;compiler-rt;lld;mlir" ../llvm/ -DLLVM_ENABLE_RTTI=ON -DCMAKE_BUILD_TYPE=Release \
-    && make -j${MAKE_THREADS}
+# Build LLVM 12 from source code.
+RUN git clone --branch release/12.x --single-branch https://github.com/llvm/llvm-project.git
+
+WORKDIR /llvm-project/build
+RUN cmake -DLLVM_ENABLE_PROJECTS="clang;openmp;compiler-rt;lld;mlir" \
+    -DLLVM_ENABLE_RTTI=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr/local/llvm \
+    ../llvm \
+    && make -j${MAKE_THREADS} \
+    && make install
+
+
+# Runner.
+FROM ubuntu:20.04
+COPY --from=builder /usr/local/llvm /usr/local/llvm
+ENV PATH=/usr/local/llvm/bin:$PATH
+WORKDIR /workspace
+ENTRYPOINT ["clang"]

--- a/Dockerfile.x-ray
+++ b/Dockerfile.x-ray
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-COPY --from=llvm-prebuilt /llvm-project /llvm-project
+COPY --from=llvm-prebuilt /usr/local/llvm /usr/local/llvm
 
 # ARG CODERRECT_LOCAL_PATH=coderrect-linux-develop.tar.gz
 # ARG CODERRECT_LOCAL_FILENAME=coderrect-linux-develop

--- a/code-detector/CMakeLists.txt
+++ b/code-detector/CMakeLists.txt
@@ -5,8 +5,8 @@ option(ENABLE_SPACE_OPT "Whether to apply aggressive memory optimzation (which w
 option(ENABLE_HEAP_PROFILE "Turn on heap profiling feature by linking to tcmalloc" OFF)
 
 # set to path in Docker
-set(LLVM_DIR /llvm-project/build/lib/cmake/llvm/)
-set(MLIR_DIR /llvm-project/build/lib/cmake/mlir/)
+set(LLVM_DIR /usr/local/llvm/lib/cmake/llvm/)
+set(MLIR_DIR /usr/local/llvm/lib/cmake/mlir/)
 
 # Do not override manually set LLVM_DIR
 if(NOT DEFINED LLVM_DIR)

--- a/code-parser/CMakeLists.txt
+++ b/code-parser/CMakeLists.txt
@@ -16,8 +16,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-set(LLVM_DIR /llvm-project/build/lib/cmake/llvm/)
-set(MLIR_DIR /llvm-project/build/lib/cmake/mlir/)
+set(LLVM_DIR /usr/local/llvm/lib/cmake/llvm)
+set(MLIR_DIR /usr/local/llvm/lib/cmake/mlir)
 
 if(NOT ENABLE_TEST)
     set(ENABLE_TEST Off) # default disable testing


### PR DESCRIPTION
This reduces the image size from 8.6GB to 3.4GB.