### PR TITLE
feat: move to LLVM 14.0.6

### DIFF
--- a/Dockerfile.llvm
+++ b/Dockerfile.llvm
@@ -27,7 +27,7 @@ RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER
 ARG MAKE_THREADS=
 
 # Build LLVM from source code.
-ARG LLVM_VERSION=12.0.1
+ARG LLVM_VERSION=14.0.6
 RUN git clone --branch=llvmorg-${LLVM_VERSION} --single-branch --depth=1 https://github.com/llvm/llvm-project.git
 
 WORKDIR /llvm-project/build

--- a/Dockerfile.x-ray
+++ b/Dockerfile.x-ray
@@ -1,7 +1,9 @@
-# Use prebuilt LLVM binaries (currently 12.0.1). Note that not using the
-# package from LLVM release as x-ray (in particular `code-parser`) requires
-# RTTI support which is not enabled in LLVM release build.
+# Use prebuilt LLVM binaries. Note that not using the package from LLVM release
+# as x-ray (in particular `code-parser`) requires RTTI support which is not
+# enabled in LLVM release build.
 ARG LLVM_PREBUILT_IMAGE=llvm-prebuilt
+ARG LLVM_VERSION=14.0.6
+
 FROM ${LLVM_PREBUILT_IMAGE} AS llvm-prebuilt
 
 # Builder.
@@ -44,8 +46,6 @@ RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER
 
 # Caller can optionally specify # of threads.
 ARG MAKE_THREADS=
-
-ARG LLVM_VERSION=12.0.1
 
 # Build x-ray detector.
 COPY code-detector x-ray-toolchain/code-detector

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ DOCKER_IMAGE_VERSION = 1.2
 RUST = false
 BINARY_PATH = ~/local/sec3/bin/coderrect
 
+# The LLVM version to use.
+LLVM_VERSION ?= 14.0.6
+
 # The default prebuilt image, which is hosted on DigitalOcean (private)
 # registry. Use `doctl registry login` to ensure the access.
-LLVM_PREBUILT_IMAGE ?= registry.digitalocean.com/soteria/llvm-prebuilt:latest
-
-# The LLVM version to use.
-LLVM_VERSION ?= 12.0.1
+LLVM_PREBUILT_IMAGE ?= registry.digitalocean.com/soteria/llvm-prebuilt-$(LLVM_VERSION):latest
 
 X_RAY_IMAGE ?= x-ray:latest
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Here's a simplified instruction for manually build and run x-ray tool on your lo
 
 ### Dependencies
 
-- LLVM 12.0.1 (support of higher version is WIP)
+- LLVM 14.0.6 (support of higher version is WIP)
 - Cmake 3.26 or higher
-- Go 1.16 or higher
+- Go 1.22 or higher
 - ANTLR 4.13.1 (only needed for parser development)
 
 ### Update CMake

--- a/code-detector/CMakeLists.txt
+++ b/code-detector/CMakeLists.txt
@@ -4,7 +4,7 @@ project(aser_pta)
 option(ENABLE_SPACE_OPT "Whether to apply aggressive memory optimzation (which will make constraint graph harder to understand)" ON)
 option(ENABLE_HEAP_PROFILE "Turn on heap profiling feature by linking to tcmalloc" OFF)
 
-set(LLVM_VERSION "12.0.1" CACHE STRING "The LLVM version")
+set(LLVM_VERSION "14.0.6" CACHE STRING "The LLVM version")
 
 # set to path in Docker
 set(LLVM_DIR "/usr/local/llvm/lib/cmake/llvm" CACHE STRING "Path to LLVM")

--- a/code-detector/include/aser/PointerAnalysis/Graph/ConstraintGraph/CGNodeBase.h
+++ b/code-detector/include/aser/PointerAnalysis/Graph/ConstraintGraph/CGNodeBase.h
@@ -5,6 +5,7 @@
 #define ASER_PTA_CGNODEBASE_H
 #include <llvm/ADT/SparseBitVector.h>
 #include <llvm/Demangle/Demangle.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Metadata.h>

--- a/code-detector/lib/aser/PointerAnalysis/Model/MemModels.cpp
+++ b/code-detector/lib/aser/PointerAnalysis/Model/MemModels.cpp
@@ -136,7 +136,7 @@ const Value *FSCanonicalizer::canonicalize(const llvm::Value *V) {
     bool changed = true;
 
     while (changed) {
-        V = V->stripPointerCastsAndInvariantGroups();
+        V = V->stripPointerCastsForAliasAnalysis();
         if (auto gep = dyn_cast<GetElementPtrInst>(V)) {
             if (gep->getNumIndices() == 1 && gep->hasAllConstantIndices()) {
                 if (auto idx = cast<ConstantInt>(gep->getOperand(1))) {

--- a/code-detector/lib/aser/PointerAnalysis/Program/Program.cpp
+++ b/code-detector/lib/aser/PointerAnalysis/Program/Program.cpp
@@ -22,7 +22,7 @@ const Function* aser::CallSite::resolveTargetFunction(const Value* calledValue) 
     }
 
     if (auto globalAlias = dyn_cast<GlobalAlias>(calledValue)) {
-        auto globalSymbol = globalAlias->getIndirectSymbol()->stripPointerCasts();
+        auto globalSymbol = globalAlias->getAliasee()->stripPointerCasts();
         if (auto function = dyn_cast<Function>(globalSymbol)) {
             return function;
         }

--- a/code-detector/lib/aser/PreProcessing/IRPreProcessor.cpp
+++ b/code-detector/lib/aser/PreProcessing/IRPreProcessor.cpp
@@ -1,10 +1,9 @@
 #include <llvm/ADT/Triple.h>
-#include <llvm/IR/LegacyPassManager.h>
-#include <llvm/CodeGen/CommandFlags.h>
-//#include <llvm/CodeGen/CommandFlags.inc>
-#include <llvm/Support/TargetRegistry.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/CodeGen/CommandFlags.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/MC/TargetRegistry.h>
 #include <llvm/Target/TargetMachine.h>
 
 #include "aser/PreProcessing/IRPreProcessor.h"

--- a/code-detector/lib/aser/PreProcessing/Passes/UnrollThreadCreateLoopPass.cpp
+++ b/code-detector/lib/aser/PreProcessing/Passes/UnrollThreadCreateLoopPass.cpp
@@ -70,19 +70,6 @@ bool UnrollThreadCreateLoopPass::runOnLoop(Loop *L, LPPassManager &LPM) {
                     // llvm::outs() << "is the latch also the exiting block?"
                     //              << (L->getLoopLatch() != L->getExitingBlock()) << "\n";
 
-                    // NOTE: The calculation of TripCount is taken from LoopUnrollPass.cpp
-                    unsigned TripCount = 0;
-                    unsigned TripMultiple = 1;
-                    // If there are multiple exiting blocks but one of them is the latch, use the
-                    // latch for the trip count estimation. Otherwise insist on a single exiting
-                    // block for the trip count estimation.
-                    BasicBlock *ExitingBlock = L->getLoopLatch();
-                    if (!ExitingBlock || !L->isLoopExiting(ExitingBlock)) ExitingBlock = L->getExitingBlock();
-                    if (ExitingBlock) {
-                        TripCount = SE->getSmallConstantTripCount(L, ExitingBlock);
-                        TripMultiple = SE->getSmallConstantTripMultiple(L, ExitingBlock);
-                    }
-
                     // NOTE: the peelLoop API seems to have soundness issue
                     // some of the loop will fail the assertion if we turn on the assertions in LLVM
                     // peelLoop(L, 1, LI, SE, DT, AC, true);
@@ -90,8 +77,7 @@ bool UnrollThreadCreateLoopPass::runOnLoop(Loop *L, LPPassManager &LPM) {
                     // NOTE: it seems only if we set ULO.count to 2, the loop unroll will take effect
                     LOG_DEBUG("unroll loop once at: {}", *inst);
                     // NOTE: the options can be more carefully tuned, I don't understand all of them -- yanze
-                    UnrollLoopOptions ULO = {2,    TripCount,    true, false, false, true,
-                                             true, TripMultiple, 0,    false, false};
+                    UnrollLoopOptions ULO = {2, true, false, false, false, false};
                     auto result = UnrollLoop(L, ULO, LI, SE, DT, AC, TTI, &ORE, true);
                     //auto result = UnrollLoop(L, ULO, LI, SE, DT, AC, &ORE, true);
                     if (result == LoopUnrollResult::Unmodified) {

--- a/code-detector/lib/aser/Util/TypeMetaData.cpp
+++ b/code-detector/lib/aser/Util/TypeMetaData.cpp
@@ -3,6 +3,7 @@
 //
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/BinaryFormat/Dwarf.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>

--- a/code-detector/lib/aser/Util/Util.cpp
+++ b/code-detector/lib/aser/Util/Util.cpp
@@ -6,6 +6,7 @@
 #include <map>
 
 #include <llvm/Demangle/Demangle.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Metadata.h>

--- a/code-detector/tools/RaceDetector/include/RDUtil.h
+++ b/code-detector/tools/RaceDetector/include/RDUtil.h
@@ -58,8 +58,7 @@ inline std::string &ltrim(std::string &s, const char *t = ws) {
 inline std::string &trim(std::string &s, const char *t = ws) { return ltrim(rtrim(s, t), t); }
 
 inline bool hasNoAliasMD(const llvm::Instruction *inst) {
-    llvm::AAMDNodes AAMD;
-    inst->getAAMetadata(AAMD);
+    auto AAMD = inst->getAAMetadata();
     return AAMD.NoAlias != nullptr;
 }
 

--- a/code-detector/tools/RaceDetector/include/RaceDetectionPass.h
+++ b/code-detector/tools/RaceDetector/include/RaceDetectionPass.h
@@ -29,7 +29,7 @@ private:
     // Type-based Alias Analysis
     llvm::TypeBasedAAResult *tbaa;
     // used by tbaa
-    llvm::AAQueryInfo aaqi;
+    llvm::SimpleAAQueryInfo aaqi;
     bool hasFoundThread = false;
     // collection of all static threads
     std::vector<StaticThread *> threadSet;

--- a/code-detector/tools/RaceDetector/src/LinkModules.cpp
+++ b/code-detector/tools/RaceDetector/src/LinkModules.cpp
@@ -139,7 +139,7 @@ bool ModuleLinker::getComdatLeader(Module &M, StringRef ComdatName,
                                    const GlobalVariable *&GVar) {
     const GlobalValue *GVal = M.getNamedValue(ComdatName);
     if (const auto *GA = dyn_cast_or_null<GlobalAlias>(GVal)) {
-        GVal = GA->getBaseObject();
+        GVal = GA->getAliaseeObject();
         if (!GVal)
             // We cannot resolve the size of the aliasee yet.
             return emitError("Linking COMDATs named '" + ComdatName +
@@ -185,7 +185,7 @@ bool ModuleLinker::computeResultingSelectionKind(StringRef ComdatName,
             // Go with Dst.
             LinkFromSrc = false;
             break;
-        case Comdat::SelectionKind::NoDuplicates:
+        case Comdat::SelectionKind::NoDeduplicate:
             return emitError("Linking COMDATs named '" + ComdatName +
                              "': noduplicates has been violated!");
         case Comdat::SelectionKind::ExactMatch:

--- a/code-parser/CMakeLists.txt
+++ b/code-parser/CMakeLists.txt
@@ -11,12 +11,11 @@ if(NOT DEFINED LLVM_DIR)
     endif()
 endif()
 
-# use C++14 as llvm-11 does
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-set(LLVM_VERSION "12.0.1" CACHE STRING "The LLVM version")
+set(LLVM_VERSION "14.0.6" CACHE STRING "The LLVM version")
 set(LLVM_DIR "/usr/local/llvm/lib/cmake/llvm" CACHE STRING "Path to LLVM")
 set(MLIR_DIR "/usr/local/llvm/lib/cmake/mlir" CACHE STRING "Path to MLIR")
 

--- a/code-parser/lib/o2/Util/Util.cpp
+++ b/code-parser/lib/o2/Util/Util.cpp
@@ -3,6 +3,7 @@
 #include <map>
 
 #include <llvm/Demangle/Demangle.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Metadata.h>

--- a/code-parser/tools/RaceDetector/CMakeLists.txt
+++ b/code-parser/tools/RaceDetector/CMakeLists.txt
@@ -18,7 +18,7 @@ llvm_map_components_to_libnames(llvm_libs
         support
         transformutils
         codegen
-        
+
         # needed when link llvm as shared library
         AggressiveInstCombine
         demangle
@@ -97,7 +97,7 @@ target_link_libraries(sol-racedetect
     MLIRParser
     MLIRPass
     MLIRSideEffectInterfaces
-    MLIRTargetLLVMIR
+    MLIRTargetLLVMIRExport
     MLIRTransforms
     )
 

--- a/code-parser/tools/RaceDetector/include/st/MLIRGen.h
+++ b/code-parser/tools/RaceDetector/include/st/MLIRGen.h
@@ -2,12 +2,13 @@
 #define MLIR_ST_MLIRGEN_H_
 
 #include <ast/AST.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/OwningOpRef.h>
 
 #include <memory>
 
 namespace mlir {
 class MLIRContext;
-class OwningModuleRef;
 }  // namespace mlir
 
 namespace st {
@@ -15,7 +16,7 @@ class ModuleAST;
 
 /// Emit IR for the given Toy moduleAST, returns a newly created MLIR module
 /// or nullptr on failure.
-mlir::OwningModuleRef mlirGen(mlir::MLIRContext &context, ModuleAST &moduleAST);
+mlir::OwningOpRef<mlir::ModuleOp> mlirGen(mlir::MLIRContext &context, ModuleAST &moduleAST);
 
 }  // namespace st
 
@@ -24,8 +25,8 @@ class ModuleAST;
 
 /// Emit IR for the given Toy moduleAST, returns a newly created MLIR module
 /// or nullptr on failure.
-mlir::OwningModuleRef mlirGenFull(mlir::MLIRContext &context,
-                                  stx::ModuleAST &moduleAST);
+mlir::OwningOpRef<mlir::ModuleOp> mlirGenFull(mlir::MLIRContext &context,
+                                              stx::ModuleAST &moduleAST);
 
 }  // namespace stx
 

--- a/code-parser/tools/RaceDetector/src/STRaceDetector.cpp
+++ b/code-parser/tools/RaceDetector/src/STRaceDetector.cpp
@@ -36,7 +36,8 @@
 #include "mlir/Parser.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Target/LLVMIR.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/Passes.h"
 
 using namespace antlr4;
@@ -460,7 +461,11 @@ bool initParser(stx::ModuleAST *module) {
   }
   return true;
 }
+
 int dumpLLVMIR(mlir::ModuleOp module) {
+  // Register the translation to LLVM IR with the MLIR context.
+  mlir::registerLLVMDialectTranslation(*module->getContext());
+
   llvm::LLVMContext llvmContext;
   auto llvmModule = mlir::translateModuleToLLVMIR(module, llvmContext);
   if (!llvmModule) {
@@ -507,7 +512,7 @@ void initLLVMIR(stx::ModuleAST *moduleAST) {
   // If we aren't dumping the AST, then we are compiling with/to MLIR.
 
   mlir::MLIRContext context;
-  mlir::OwningModuleRef module;
+  mlir::OwningOpRef<mlir::ModuleOp> module;
   //   //from parse tree to moduleAST
   //   //TODO: add parseModule
   //   ParserWrapper wrapper(parser);
@@ -542,6 +547,7 @@ void initLLVMIR(stx::ModuleAST *moduleAST) {
       if (DEBUG_SOL) llvm::errs() << "Errors in createLowerToLLVMPass.\n";
     }
   }
+
   dumpLLVMIR(*module);
 }
 

--- a/code-parser/tools/RaceDetector/src/st/LowerToLLVM.cpp
+++ b/code-parser/tools/RaceDetector/src/st/LowerToLLVM.cpp
@@ -17,6 +17,8 @@
 
 #include "llvm/ADT/Sequence.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
@@ -48,7 +50,7 @@ void STToLLVMLoweringPass::runOnOperation() {
   // final target for this lowering. For this lowering, we are only targeting
   // the LLVM dialect.
   LLVMConversionTarget target(getContext());
-  target.addLegalOp<ModuleOp, ModuleTerminatorOp>();
+  target.addLegalOp<ModuleOp>();
 
   // During this lowering, we will also be lowering the MemRef types, that are
   // currently being operated on, to a representation in LLVM. To perform this
@@ -68,10 +70,10 @@ void STToLLVMLoweringPass::runOnOperation() {
 
   // OwningRewritePatternList patterns;
   // MLIRContext *context = &getContext();
-  OwningRewritePatternList patterns;
+  RewritePatternSet patterns(&getContext());
 
-  populateAffineToStdConversionPatterns(patterns, &getContext());
-  populateLoopToStdConversionPatterns(patterns, &getContext());
+  populateAffineToStdConversionPatterns(patterns);
+  populateLoopToStdConversionPatterns(patterns);
   populateStdToLLVMConversionPatterns(typeConverter, patterns);
 
   // The only remaining operation to lower from the `toy` dialect, is the


### PR DESCRIPTION
Upgrading from 12.0.1. It also renames the default LLVM prebuilt image to be version suffixed (i.e. `llvm-prebuilt-14.0.6`).