### PR TITLE
ci: separate pre/post-submit workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,16 @@
-name: X-ray CI
+name: Build X-ray
+
+# Avoid having multiple builds simultaneously.
+concurrency:
+  group: build-x-ray
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
-  build-and-run:
+  build-and-test:
     runs-on: self-hosted
     env:
       X_RAY_IMAGE: x-ray-ci

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,43 @@
+name: Presubmit on PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: self-hosted
+    env:
+      X_RAY_IMAGE: x-ray-ci-presubmit-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log into DigitalOcean container registry
+        run: doctl registry login --expiry-seconds 600
+
+      - name: Build Docker image
+        run: |
+          make -j build-image
+
+      - name: Test with demo program
+        run: |
+          make -j run-test
+
+      - name: Clean up containers
+        if: always()
+        run: |
+          docker ps --all --quiet --filter ancestor=x-ray:latest | xargs -r docker stop
+          docker ps --all --quiet --filter ancestor=x-ray:latest | xargs -r docker rm


### PR DESCRIPTION
In post-submit build, limit the concurrency to 1. In pre-submit build, it uses a unique image ID each time.