### PR TITLE
feat(build): install cmake via APT

### DIFF
--- a/Dockerfile.llvm
+++ b/Dockerfile.llvm
@@ -3,24 +3,19 @@ FROM ubuntu:22.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install build tools.
+# Prepare for installing CMake via APT (ref: https://apt.kitware.com/).
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y curl && \
+    curl -sSf https://apt.kitware.com/kitware-archive.sh | sh
+
+# Install build tools.
+RUN apt-get install -y \
         build-essential \
         clang-14 \
+        cmake \
         git \
-        software-properties-common \
-        wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Use prebuilt CMake binary release.
-ARG CMAKE_VERSION=3.30.1
-RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh \
-    && mkdir /opt/cmake \
-    && sh cmake-${CMAKE_VERSION}-linux-x86_64.sh --prefix=/opt/cmake --skip-license \
-    && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
-    && rm cmake-${CMAKE_VERSION}-linux-x86_64.sh
 
 # Caller can optionally specify # of threads.
 ARG MAKE_THREADS=

--- a/Dockerfile.x-ray
+++ b/Dockerfile.x-ray
@@ -16,29 +16,26 @@ RUN llvm-config --version
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Prepare for installing CMake via APT (ref: https://apt.kitware.com/).
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -sSf https://apt.kitware.com/kitware-archive.sh | sh
+
 # Build tools and dependencies.
 # Go: Pick up the latest stable (1.22 as of July 2024) via
 # https://go.dev/wiki/Ubuntu#using-ppa.
-RUN apt-get update \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y software-properties-common \
     && add-apt-repository ppa:longsleep/golang-backports \
     && apt-get update \
     && apt-get install -y \
         build-essential \
+        cmake \
         golang-go \
         wget \
         git \
         zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Use prebuilt CMake binary release.
-ARG CMAKE_VERSION=3.30.1
-RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh \
-    && mkdir /opt/cmake \
-    && sh cmake-${CMAKE_VERSION}-linux-x86_64.sh --prefix=/opt/cmake --skip-license \
-    && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
-    && rm cmake-${CMAKE_VERSION}-linux-x86_64.sh
 
 WORKDIR /x-ray-toolchain
 ARG VERSION=unknown


### PR DESCRIPTION
1. This avoids directly calling platform-specific code (e.g. `cmake-ver-linux-x86_64.sh`);
2. It automatically picks up the latest stable cmake version.